### PR TITLE
Configurable case-sensitivity and bootstrap per metric

### DIFF
--- a/app/ApiModule/presenters/MetricsPresenter.php
+++ b/app/ApiModule/presenters/MetricsPresenter.php
@@ -21,10 +21,7 @@ class MetricsPresenter extends \Nette\Application\UI\Presenter {
 
 	public function renderDefault() {
 		$response = array();
-		$response[ 'metrics' ] = array();
-		foreach( $this->metricsModel->getMetrics() as $metric ) {
-			$response[ 'metrics' ][] = $metric->name;
-		}
+		$response[ 'metrics' ] = $this->metricsModel->getEnabledMetrics();
 
 		$this->sendResponse( new \Nette\Application\Responses\JsonResponse( $response ) );
 	}
@@ -43,9 +40,9 @@ class MetricsPresenter extends \Nette\Application\UI\Presenter {
 		$tasks = array();
 		$metrics = array();
 
-		foreach( $this->metricsModel->getMetrics() as $metric ) {
-			$metrics[ $metric->name ] = array(
-				'name' => $metric->name,
+		foreach( $this->metricsModel->getEnabledMetrics() as $metric ) {
+			$metrics[ $metric ] = array(
+				'name' => $metric,
 				'data' => array()
 			);
 		}
@@ -54,13 +51,13 @@ class MetricsPresenter extends \Nette\Application\UI\Presenter {
 			$tasks[ $task->id ] = $task->name;
 
 			foreach( $this->tasksModel->getTaskMetrics( $task ) as $name => $score ) {
+				if( !$this->metricsModel->isMetricEnabled( $name ) ) {
+					continue;
+				}
+
 				$metrics[ $name ][ 'data' ][ $task->id ] = $score;
 			}
 		}
-
-		$metrics = array_filter( $metrics, function( $metric ) {
-			return strpos( $metric[ 'name' ], '-cis' ) === FALSE;
-		} );
 
 		$response = array(
 			'tasks' => $tasks,

--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -80,15 +80,56 @@ common:
 					@ngramsCounterPreprocessor
 				] ),
 				[
-					BLEU: @bleuMetric,
-					PRECISION: @arithmeticPrecisionMetric,
-					RECALL: @arithmeticRecallMetric,
-					F-MEASURE: @fmeasureMetric,
-					#H-WORDORDER: @hjersonWOMetric,
-					#H-ADDITION: @hjersonAdditionMetric,
-					#H-MISTRANSLATION: @hjersonMistranslationMetric,
-					#H-OMISSION: @hjersonOmissionMetric,
-					#H-FORM: @hjersonFormMetric,
+					BLEU-cis: [
+						class: @bleuMetric,
+						case_sensitive: False,
+						compute_bootstrap: True,
+					],
+					BLEU: [
+						class: @bleuMetric,
+						case_sensitive: True,
+						compute_bootstrap: False,
+					],
+					PRECISION: [
+						class: @arithmeticPrecisionMetric,
+						case_sensitive: False,
+						compute_bootstrap: False,
+					],
+					RECALL: [
+						class: @arithmeticRecallMetric,
+						case_sensitive: False,
+						compute_bootstrap: False,
+					],
+					F-MEASURE: [
+						class: @fmeasureMetric,
+						case_sensitive: False,
+						compute_bootstrap: False,
+					],
+					#H-WORDORDER: [
+					#	class: @hjersonWOMetric,
+					#	case_sensitive: False,
+					#	compute_bootstrap: False,
+					#],
+					#H-ADDITION: [
+					#	class: @hjersonAdditionMetric,
+					#	case_sensitive: False,
+					#	compute_bootstrap: False,
+					#],
+					#H-MISTRANSLATION: [
+					#	class: @hjersonMistranslationMetric,
+					#	case_sensitive: False,
+					#	compute_bootstrap: False,
+					#],
+					#H-OMISSION: [
+					#	class: @hjersonOmissionMetric,
+					#	case_sensitive: False,
+					#	compute_bootstrap: False,
+					#],
+					#H-FORM: [
+					#	class: @hjersonFormMetric,
+					#	case_sensitive: False,
+					#	compute_bootstrap: False,
+					#],
 				]
 			)
 			setup:
@@ -106,11 +147,6 @@ common:
 		ngramsPreprocessor: NGramsPreprocessor
 		confirmedNGramsPreprocessor: ConfirmedNGramsPreprocessor( ConfirmedNGramsFinder() )
 		ngramsCounterPreprocessor: NGramsCounterPreprocessor
-
-
-
-
-
 
 production < common:
 

--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -79,62 +79,64 @@ common:
 					@confirmedNGramsPreprocessor
 					@ngramsCounterPreprocessor
 				] ),
-				[
-					BLEU-cis: [
-						class: @bleuMetric,
-						case_sensitive: False,
-						compute_bootstrap: True,
-					],
-					BLEU: [
-						class: @bleuMetric,
-						case_sensitive: True,
-						compute_bootstrap: False,
-					],
-					PRECISION: [
-						class: @arithmeticPrecisionMetric,
-						case_sensitive: False,
-						compute_bootstrap: False,
-					],
-					RECALL: [
-						class: @arithmeticRecallMetric,
-						case_sensitive: False,
-						compute_bootstrap: False,
-					],
-					F-MEASURE: [
-						class: @fmeasureMetric,
-						case_sensitive: False,
-						compute_bootstrap: False,
-					],
-					#H-WORDORDER: [
-					#	class: @hjersonWOMetric,
-					#	case_sensitive: False,
-					#	compute_bootstrap: False,
-					#],
-					#H-ADDITION: [
-					#	class: @hjersonAdditionMetric,
-					#	case_sensitive: False,
-					#	compute_bootstrap: False,
-					#],
-					#H-MISTRANSLATION: [
-					#	class: @hjersonMistranslationMetric,
-					#	case_sensitive: False,
-					#	compute_bootstrap: False,
-					#],
-					#H-OMISSION: [
-					#	class: @hjersonOmissionMetric,
-					#	case_sensitive: False,
-					#	compute_bootstrap: False,
-					#],
-					#H-FORM: [
-					#	class: @hjersonFormMetric,
-					#	case_sensitive: False,
-					#	compute_bootstrap: False,
-					#],
-				]
+				@enabledMetrics,
 			)
 			setup:
 				- setLogger( @logger )
 				- setNormalizer( @normalizer )
+
+		enabledMetrics:	EnabledMetricsList( [
+			BLEU-cis: [
+				class: @bleuMetric,
+				case_sensitive: False,
+				compute_bootstrap: True,
+			],
+			BLEU: [
+				class: @bleuMetric,
+				case_sensitive: True,
+				compute_bootstrap: False,
+			],
+			PRECISION: [
+				class: @arithmeticPrecisionMetric,
+				case_sensitive: False,
+				compute_bootstrap: False,
+			],
+			RECALL: [
+				class: @arithmeticRecallMetric,
+				case_sensitive: False,
+				compute_bootstrap: False,
+			],
+			F-MEASURE: [
+				class: @fmeasureMetric,
+				case_sensitive: False,
+				compute_bootstrap: False,
+			],
+			#H-WORDORDER: [
+			#	class: @hjersonWOMetric,
+			#	case_sensitive: False,
+			#	compute_bootstrap: False,
+			#],
+			#H-ADDITION: [
+			#	class: @hjersonAdditionMetric,
+			#	case_sensitive: False,
+			#	compute_bootstrap: False,
+			#],
+			#H-MISTRANSLATION: [
+			#	class: @hjersonMistranslationMetric,
+			#	case_sensitive: False,
+			#	compute_bootstrap: False,
+			#],
+			#H-OMISSION: [
+			#	class: @hjersonOmissionMetric,
+			#	case_sensitive: False,
+			#	compute_bootstrap: False,
+			#],
+			#H-FORM: [
+			#	class: @hjersonFormMetric,
+			#	case_sensitive: False,
+			#	compute_bootstrap: False,
+			#],
+		] )
 
 		# Importers dependencies
 		logger: EchoLogger

--- a/app/model/Metrics.php
+++ b/app/model/Metrics.php
@@ -7,8 +7,11 @@ class Metrics {
 
 	private $db;
 
-	public function __construct( Nette\Database\Context $db ) {
+	private $enabledMetrics;
+
+	public function __construct( Nette\Database\Context $db, EnabledMetricsList $enabledMetrics ) {
 		$this->db = $db;
+		$this->enabledMetrics = (array) $enabledMetrics;
 	}
 
 	public function getMetrics() {
@@ -90,4 +93,13 @@ class Metrics {
 			->order( 'sample_position' );
 	}
 
+
+	public function getEnabledMetrics() {
+		return array_keys( $this->enabledMetrics );
+	}
+
+
+	public function isMetricEnabled( $metric ) {
+		return array_key_exists( $metric, $this->enabledMetrics );
+	}
 }

--- a/libs/Metrics/EnabledMetricsList.php
+++ b/libs/Metrics/EnabledMetricsList.php
@@ -1,0 +1,5 @@
+<?php
+
+class EnabledMetricsList extends ArrayObject {
+
+}


### PR DESCRIPTION
In config.neon, you can now setup which metrics should be case sensitive and for which metrics a bootstrap resampling significance should be computed:

```
BLEU-cis: [
   class: @bleuMetric,
   case_sensitive: False,
   compute_bootstrap: True,
],
BLEU: [
   class: @bleuMetric,
   case_sensitive: True,
   compute_bootstrap: False,
],